### PR TITLE
Improve UI test stability and runtime

### DIFF
--- a/LogReaderFactory.php
+++ b/LogReaderFactory.php
@@ -26,7 +26,8 @@ class LogReaderFactory
 
         switch ($source) {
             case 'file':
-                $path = StaticContainer::get('log.file.filename');
+                $testFilePath = StaticContainer::get('test.vars.logForReading');
+                $path = $testFilePath ?: StaticContainer::get('log.file.filename');
 
                 return new File($path);
 

--- a/tests/Fixtures/EmptySite.php
+++ b/tests/Fixtures/EmptySite.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LogViewer\tests\Fixtures;
+
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * Fixture that adds one site with no visits
+ */
+class EmptySite extends Fixture
+{
+    public $idSite = 1;
+    public function setUp(): void
+    {
+        Fixture::createSuperUser();
+        $this->setUpWebsites();
+    }
+    public function tearDown(): void
+    {
+        // empty
+    }
+    private function setUpWebsites()
+    {
+        if (!self::siteCreated($idSite = 1)) {
+            self::createWebsite('2021-01-01');
+        }
+    }
+}

--- a/tests/UI/LogViewer_spec.js
+++ b/tests/UI/LogViewer_spec.js
@@ -10,6 +10,8 @@
 describe("LogViewer", function () {
     this.timeout(0);
 
+    this.fixture = "Piwik\\Plugins\\LogViewer\\tests\\Fixtures\\EmptySite";
+
     var generalParams = 'idSite=1&period=day&date=2010-01-03';
 
     async function searchForText(textToAppendToSearchField)
@@ -47,9 +49,9 @@ describe("LogViewer", function () {
         testEnvironment.configOverride = {
             log: {
                 'log_writers': logWriters,
-                'logger_file_path': PIWIK_INCLUDE_PATH + '/plugins/LogViewer/tests/resources/piwik.log'
             }
         };
+        testEnvironment.logForReading = PIWIK_INCLUDE_PATH + '/plugins/LogViewer/tests/resources/piwik.log';
         testEnvironment.save();
     }
 


### PR DESCRIPTION
### Description:

The UI tests of this plugin are also running in our core builds. There it happens quite often that the UI tests are failing as additional error message occur in the log files, as e.g. there is a temporary error while generating the assets.

This happens, as the UI tests currently overwrite the log file position, with a file specially created for tests. New log entries are therefor directly written to the file and the UI tests display them.
This PR changes the behavior, so the log file position actually isn't overwritten, but the ReaderFactory in this plugin responsible for reading the log file use the customized path for reading only. That way no new messages can appear in the tests.

In addition I've also speeded the tests up ab bit by adding a nearly empty fixture, that will be used in the UI tests. Using the default fixture works as well, but takes a lot longer to be set up.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
