### PR TITLE
Fixed dependency error

### DIFF
--- a/LogReaderFactory.php
+++ b/LogReaderFactory.php
@@ -26,7 +26,12 @@ class LogReaderFactory
 
         switch ($source) {
             case 'file':
-                $testFilePath = StaticContainer::get('test.vars.logForReading');
+                $testFilePath = '';
+                try {
+                    $testFilePath = StaticContainer::get('test.vars.logForReading');
+                } catch (\Throwable $th) {
+                    // Do nothing
+                }
                 $path = $testFilePath ?: StaticContainer::get('log.file.filename');
 
                 return new File($path);


### PR DESCRIPTION
### Description:

I went to use LogViewer and noticed that I was getting an exception instead of loading the log. This fixes the exception that I missed while reviewing PR #91 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
